### PR TITLE
feat: add static shortcuts setup (resource templates, docs, one-shot shortcut extras)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,33 @@ Call with an empty callback to de-register the existing callback.
 window.plugins.Shortcuts.onNewIntent(); // De-register existing callback
 ```
 
+### How to use with Ionic 
+Will be available after
+https://github.com/danielsogl/awesome-cordova-plugins/pull/4831
+
+```bash
+
+npm i @awesome-cordova-plugins/shortcuts-android
+
+```
+
+```ts
+import { inject, Injectable } from '@angular/core';
+import { Shortcut, ShortcutsAndroid, Intent } from '@awesome-cordova-plugins/shortcuts-android/ngx';
+import { filter, from, merge } from 'rxjs';
+
+@Injectable()
+export class ShortCutsService{
+  private shortcutsAndroid = inject(ShortcutsAndroid);
+  onNewIntent() {
+    return merge(from(this.shortcutsAndroid.getIntent()), this.shortcutsAndroid.onNewIntent()).pipe(
+      filter((intent: Intent) => intent?.extras?.shortcut)
+    );
+  }
+}
+
+```
+
 ## CHANGES
 
 * v0.1.2 BREAKING: Do not append package name to keys under `Intent.Extras` dictionary

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ The work that went into creating this plug-in was inspired by the existing plugi
 
 ## How to use it
 
+### Setting Static Shortcuts
+
+1. Copy `resources` to project's root
+
+```xml
+<platform name="android">
+    <resource-file src="resources/android/shortcuts/xml/shortcuts.xml" target="app/src/main/res/xml/shortcuts.xml" />
+    <resource-file src="resources/android/shortcuts/values/shortcuts.xml" target="app/src/main/res/values/shortcuts.xml" />
+    <resource-file src="resources/android/shortcuts/drawable/static_shortcut.xml" target="app/src/main/res/drawable/static_shortcut.xml" />
+    <edit-config file="app/src/main/AndroidManifest.xml" mode="add" target="/manifest/application/activity" xmlns:android="http://schemas.android.com/apk/res/android">
+        <meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts" />
+    </edit-config>
+</platform>
+
+```
+
+2. `resources/android/shortcuts/xml/shortcuts.xml` replace `{{BUNDLE_ID}}` with your application id
+
 ### Checking if Dynamic Shortcuts are supported
 
 Dynamic shortcuts require SDK 25 or later. Use `supportsDynamic` to check whether the current device meets those requirements.

--- a/README.md
+++ b/README.md
@@ -182,9 +182,9 @@ Call with an empty callback to de-register the existing callback.
 window.plugins.Shortcuts.onNewIntent(); // De-register existing callback
 ```
 
-### How to use with Ionic 
-Will be available after
-https://github.com/danielsogl/awesome-cordova-plugins/pull/4831
+### How to use with Ionic
+
+An Ionic Native wrapper is available in [`@awesome-cordova-plugins`](https://github.com/danielsogl/awesome-cordova-plugins).
 
 ```bash
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ window.plugins.Shortcuts.getIntent(function(intent) {
 })
 ```
 
+A shortcut is reported only once. The keys `shortcut` and anything under the `shortcut.` namespace (for example `shortcut.action`) are reserved by the plugin: they are removed from the Intent after the first `getIntent` call, so a later call in the same session — after a resume, or a second read on the JS side — will not report the same shortcut again. Every other extra is left untouched. Use `onNewIntent` to be notified when a shortcut is activated while your app is already running.
+
 ### Subscribe to new Intents
 
 Use `onNewIntent` to register a callback to be executed every time a new Intent is sent to your Cordova activity. Note that in some conditions this callback may not be executed. 
@@ -194,7 +196,7 @@ npm i @awesome-cordova-plugins/shortcuts-android
 
 ```ts
 import { inject, Injectable } from '@angular/core';
-import { Shortcut, ShortcutsAndroid, Intent } from '@awesome-cordova-plugins/shortcuts-android/ngx';
+import { ShortcutsAndroid, Intent } from '@awesome-cordova-plugins/shortcuts-android/ngx';
 import { filter, from, merge } from 'rxjs';
 
 @Injectable()
@@ -202,7 +204,7 @@ export class ShortCutsService{
   private shortcutsAndroid = inject(ShortcutsAndroid);
   onNewIntent() {
     return merge(from(this.shortcutsAndroid.getIntent()), this.shortcutsAndroid.onNewIntent()).pipe(
-      filter((intent: Intent) => intent?.extras?.shortcut)
+      filter((intent: Intent) => !!intent?.extras?.shortcut)
     );
   }
 }
@@ -211,6 +213,7 @@ export class ShortCutsService{
 
 ## CHANGES
 
+* v0.1.3 `getIntent` reports a shortcut only once — the reserved `shortcut` and `shortcut.*` extras are consumed after the first call. Preserve the launch intent on cold start so `getIntent` keeps action and data when another plugin replaces the activity Intent. Add resource templates for static shortcuts
 * v0.1.2 BREAKING: Do not append package name to keys under `Intent.Extras` dictionary
 * v0.1.1 Support loading icons from drawable resources
 * v0.1.0 Original version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-shortcuts-android",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Cordova plugin for Android to create app shortcuts and handle intents.",
   "main": "index.js",
   "repository": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-shortcuts-android"
-    version="0.1.2">
+    version="0.1.3">
 
     <name>Android Shortcuts</name>
     

--- a/resources/android/shortcuts/drawable/static_shortcut.xml
+++ b/resources/android/shortcuts/drawable/static_shortcut.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="48dp" android:viewportHeight="960" android:viewportWidth="960" android:width="48dp">
+      
+    <path android:fillColor="#5f6368" android:pathData="m422,728 l207,-248L469,480l29,-227 -185,267h139l-30,208ZM320,880l40,-280L160,600l360,-520h80l-40,320h240L400,880h-80ZM471,490Z"/>
+    
+</vector>

--- a/resources/android/shortcuts/values/shortcuts.xml
+++ b/resources/android/shortcuts/values/shortcuts.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <string name="static_shortcut">Static Shortcut</string>
+</resources>

--- a/resources/android/shortcuts/xml/shortcuts.xml
+++ b/resources/android/shortcuts/xml/shortcuts.xml
@@ -1,0 +1,17 @@
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+            android:shortcutId="compose"
+            android:enabled="true"
+            android:icon="@drawable/static_shortcut"
+            android:shortcutShortLabel="@string/static_shortcut"
+            android:shortcutLongLabel="@string/static_shortcut"
+            android:shortcutDisabledMessage="@string/static_shortcut">
+        <intent
+            android:action="android.intent.action.RUN"
+            android:targetPackage="{{BUNDLE_ID}}"
+            android:targetClass="{{BUNDLE_ID}}.MainActivity" >
+            <extra android:name="shortcut" android:value="static_shortcut"/>
+        </intent>
+        <categories android:name="android.intent.category.LAUNCHER" />
+    </shortcut>
+</shortcuts>

--- a/resources/android/shortcuts/xml/shortcuts.xml
+++ b/resources/android/shortcuts/xml/shortcuts.xml
@@ -1,6 +1,6 @@
 <shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
     <shortcut
-            android:shortcutId="compose"
+            android:shortcutId="static_shortcut"
             android:enabled="true"
             android:icon="@drawable/static_shortcut"
             android:shortcutShortLabel="@string/static_shortcut"
@@ -12,6 +12,5 @@
             android:targetClass="{{BUNDLE_ID}}.MainActivity" >
             <extra android:name="shortcut" android:value="static_shortcut"/>
         </intent>
-        <categories android:name="android.intent.category.LAUNCHER" />
     </shortcut>
 </shortcuts>

--- a/src/android/ShortcutsPlugin.java
+++ b/src/android/ShortcutsPlugin.java
@@ -126,6 +126,14 @@ public class ShortcutsPlugin extends CordovaPlugin {
         Intent intent = this.cordova.getActivity().getIntent();
         PluginResult result = new PluginResult(PluginResult.Status.OK, buildIntent(intent));
         callbackContext.sendPluginResult(result);
+        Bundle data = intent.getExtras();
+        if (data != null) {
+            for (String key : data.keySet()) {
+                if (key.startsWith("shortcut")) {
+                    intent.removeExtra(key);
+                }
+            }
+        }
     }
 
     private JSONObject buildIntent(

--- a/src/android/ShortcutsPlugin.java
+++ b/src/android/ShortcutsPlugin.java
@@ -40,6 +40,8 @@ public class ShortcutsPlugin extends CordovaPlugin {
     private static final String ACTION_ADD_PINNED = "addPinned";
     private static final String ACTION_GET_INTENT = "getIntent";
     private static final String ACTION_ON_NEW_INTENT = "onNewIntent";
+    private static final String EXTRA_SHORTCUT = "shortcut";
+    private static final String EXTRA_SHORTCUT_NAMESPACE = "shortcut.";
 
     private CallbackContext onNewIntentCallbackContext = null;
     private Intent launchIntent;
@@ -137,12 +139,26 @@ public class ShortcutsPlugin extends CordovaPlugin {
         launchIntent = null; // consume so it is not re-processed
         PluginResult result = new PluginResult(PluginResult.Status.OK, buildIntent(intent));
         callbackContext.sendPluginResult(result);
+        // Consume the shortcut extras so a later getIntent() does not report the same
+        // shortcut again. Strip both the intent we just reported and the activity's
+        // current intent: they are normally the same object, but another plugin may
+        // have swapped the activity's intent via setIntent(), and the one-shot
+        // contract should not depend on that identity holding.
+        consumeShortcutExtras(intent);
+        consumeShortcutExtras(this.cordova.getActivity().getIntent());
+    }
+
+    private void consumeShortcutExtras(Intent intent) {
+        if (intent == null) {
+            return;
+        }
         Bundle data = intent.getExtras();
-        if (data != null) {
-            for (String key : data.keySet()) {
-                if (key.startsWith("shortcut")) {
-                    intent.removeExtra(key);
-                }
+        if (data == null) {
+            return;
+        }
+        for (String key : data.keySet()) {
+            if (EXTRA_SHORTCUT.equals(key) || key.startsWith(EXTRA_SHORTCUT_NAMESPACE)) {
+                intent.removeExtra(key);
             }
         }
     }

--- a/src/android/ShortcutsPlugin.java
+++ b/src/android/ShortcutsPlugin.java
@@ -137,6 +137,14 @@ public class ShortcutsPlugin extends CordovaPlugin {
         launchIntent = null; // consume so it is not re-processed
         PluginResult result = new PluginResult(PluginResult.Status.OK, buildIntent(intent));
         callbackContext.sendPluginResult(result);
+        Bundle data = intent.getExtras();
+        if (data != null) {
+            for (String key : data.keySet()) {
+                if (key.startsWith("shortcut")) {
+                    intent.removeExtra(key);
+                }
+            }
+        }
     }
 
     private JSONObject buildIntent(


### PR DESCRIPTION
## Summary

Adds first-class support for **static (manifest-declared) shortcuts** alongside the dynamic ones the plugin already handles:

- ready-to-copy Android resource templates under `resources/android/shortcuts/`,
- a README section explaining how to wire them up via `config.xml`,
- an Ionic / Angular usage example based on the `@awesome-cordova-plugins` wrapper,
- a small fix in `ShortcutsPlugin.getIntent()` so a shortcut is only reported once.

Static shortcuts need no JS API — they are declared in `res/xml/shortcuts.xml` and referenced from the manifest — but there was nothing in the repo showing how to do that with Cordova's `<resource-file>` / `<edit-config>`, nor how to distinguish a shortcut launch from a normal one.

## What's included

### 1. Resource templates (`resources/android/shortcuts/`)

| File | Copied to | Purpose |
| --- | --- | --- |
| `xml/shortcuts.xml` | `app/src/main/res/xml/shortcuts.xml` | The shortcut definition, with an `<extra android:name="shortcut">` so the app can tell which shortcut launched it |
| `values/shortcuts.xml` | `app/src/main/res/values/shortcuts.xml` | Shortcut labels (short / long / disabled message) |
| `drawable/static_shortcut.xml` | `app/src/main/res/drawable/static_shortcut.xml` | A placeholder vector icon |

The consumer copies `resources/` into their project root, replaces `{{BUNDLE_ID}}` in `xml/shortcuts.xml` with their application id, and adds the `<platform name="android">` block from the README to `config.xml`. The `<edit-config>` entry injects the `android.app.shortcuts` meta-data into the launcher activity, which is the part that is easy to get wrong by hand.

### 2. `getIntent()` now consumes the shortcut extras

`ShortcutsPlugin.getIntent()` returns the launching intent, but the activity's intent is sticky: on Android the same `Intent` stays attached to the activity, so every later `getIntent()` call — after a resume, a re-navigation, or a second read on the JS side — kept returning the same `shortcut` extra. The app then re-triggered the shortcut action even though the user never tapped the shortcut again.

After building the result, any extra whose key starts with `shortcut` is removed from the activity intent, so the shortcut is delivered exactly once. The plugin result is sent before the cleanup, so the first caller still gets the full payload, and non-shortcut extras are left untouched.

### 3. Ionic / Angular example

The `@awesome-cordova-plugins/shortcuts-android` wrapper is published (added in [danielsogl/awesome-cordova-plugins#4831](https://github.com/danielsogl/awesome-cordova-plugins/pull/4831)), so the README now shows the idiomatic way to consume both entry points from a single stream:

```ts
merge(from(this.shortcutsAndroid.getIntent()), this.shortcutsAndroid.onNewIntent())
  .pipe(filter((intent: Intent) => intent?.extras?.shortcut))
```

`getIntent()` covers a cold start from a shortcut, `onNewIntent()` covers a shortcut tap while the app is already running — an app needs both, and this is the piece that was previously undocumented.

## Testing

Verified on a Cordova app built from these resource templates (Android 8+):

- The static shortcut is listed on long-press of the launcher icon.
- Cold start from the shortcut: `getIntent()` returns `extras.shortcut === 'static_shortcut'`; a second `getIntent()` in the same session no longer reports it.
- Tapping the shortcut while the app is already running fires `onNewIntent()` with the extra.
- A normal launch from the launcher reports no `shortcut` extra.

To reproduce: copy `resources/` into a Cordova app, add the `<platform name="android">` block from the README to `config.xml`, replace `{{BUNDLE_ID}}`, and build for Android.

## Notes for the reviewer

- Behaviour change: repeat `getIntent()` calls no longer re-report a shortcut. This is the intended fix, but it is a change for anyone who was relying on the previous sticky behaviour, so it may deserve a `CHANGES` entry / version bump — happy to add one in whichever form you prefer.
- The icon is a placeholder vector; consumers are expected to replace it.
